### PR TITLE
Update registrars page to correct broken link

### DIFF
--- a/source/registrars/index.html
+++ b/source/registrars/index.html
@@ -161,7 +161,7 @@ active: registrars
 			</a>
 		</div>
 		<div class="col-sm-6 col-md-4">
-			<a class="btn btn-default registrar-resource" role="button" href="12012016-eco-logo-space-guidelines.pdf">
+			<a class="btn btn-default registrar-resource" role="button" href="/assets/12012016-eco-logo-space-guidelines.pdf">
 				<i class="fa fa-file-pdf-o" aria-hidden="true"></i>
 				<p>Brand guidelines</p>
 			</a>


### PR DESCRIPTION
/assets/ was missing from 12012016-eco-logo-space-guidelines.pdf